### PR TITLE
Global iptables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Additional optional role vars:
 
 ## Dependencies
 + ho-ansible.systemd-networkd
++ ho-ansible.iptables
 
 ## Example Playbook
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,3 +17,4 @@ galaxy_info:
 
 dependencies:
 - systemd-networkd
+- iptables


### PR DESCRIPTION
The ho-ansible/iptables role manages a global rule set loaded on startup.

For systemd services, the hooks `ExecStart` et al can be used to add and remove iptables rules so that they exist only while the service is running.

However, this clashes with the use of `iptables-persistent`, which may save the current set of rules at any time, potentially resulting in ephemeral rules being restored on reboot, and subsequently creating duplicate rules.

This PR is an experiment to revert to manipulating a single rule set loaded on boot, using the iptables role.